### PR TITLE
서버에 at 설치 스크립트 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,11 +45,11 @@ jobs:
           port: 22
           script_stop: true
           script: |
-            sudo apt update -y && sudo apt install -y openjdk-17-jdk
+            sudo apt update -y && sudo apt install -y openjdk-17-jdk at
             for pid in $(pgrep java); do
               if ps -p $pid -o args= | grep -q 'java -jar'; then
                 echo "Java process with 'java -jar' found (PID: $pid). Terminating..."
                 kill -9 $pid
               fi
             done
-            nohup java -jar ~/*.jar > ~/app.log 2>&1 &
+            echo "java -jar ~/*.jar > ~/app.log 2>&1 &" | at now


### PR DESCRIPTION
nohup java -jar ~/*.jar > ~/app.log 2>&1 & 명령을 실행했는데 서버에서 애플리케이션이 실행되지 않는다면, 백그라운드 실행 프로세스(nohup)가 SSH 세션 종료와 함께 종료되는 문제가 생길 수 있음